### PR TITLE
Add simple number guessing game

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
           <ul class="nav-list">
             <li><a href="#home">Home</a></li>
             <li><a href="#about">About</a></li>
+            <li><a href="#game">Game</a></li>
             <li><a href="#contact">Contact</a></li>
           </ul>
         </nav>
@@ -87,6 +88,19 @@
             <h2>Deploy</h2>
             <p>Drop these files into a GitHub repo and enable GitHub Pages. Relative asset paths make it work at <code>/REPO/</code> or a custom domain.</p>
           </div>
+        </div>
+      </section>
+
+      <section id="game" class="section">
+        <div class="container">
+          <h2>Guess the Number</h2>
+          <p>Pick a number between 1 and 10:</p>
+          <div class="game-controls">
+            <input type="number" id="guess-input" min="1" max="10" />
+            <button id="guess-button">Guess</button>
+            <button id="reset-button" hidden>Play again</button>
+          </div>
+          <p id="game-message" class="muted" aria-live="polite"></p>
         </div>
       </section>
 

--- a/script.js
+++ b/script.js
@@ -52,3 +52,36 @@ if (!reduceMotion) {
   });
 }
 
+// Number guessing mini game
+const guessInput = document.getElementById('guess-input');
+const guessBtn = document.getElementById('guess-button');
+const resetBtn = document.getElementById('reset-button');
+const gameMsg = document.getElementById('game-message');
+if (guessInput && guessBtn && resetBtn && gameMsg) {
+  let secret = Math.floor(Math.random() * 10) + 1;
+  const reset = () => {
+    secret = Math.floor(Math.random() * 10) + 1;
+    guessInput.value = '';
+    gameMsg.textContent = '';
+    guessBtn.disabled = false;
+    resetBtn.hidden = true;
+    guessInput.focus();
+  };
+  guessBtn.addEventListener('click', () => {
+    const guess = Number(guessInput.value);
+    if (!guess || guess < 1 || guess > 10) {
+      gameMsg.textContent = 'Enter a number from 1 to 10.';
+      return;
+    }
+    if (guess === secret) {
+      gameMsg.textContent = 'You got it!';
+      guessBtn.disabled = true;
+      resetBtn.hidden = false;
+      resetBtn.focus();
+    } else {
+      gameMsg.textContent = guess < secret ? 'Too low.' : 'Too high.';
+    }
+  });
+  resetBtn.addEventListener('click', reset);
+}
+

--- a/style.css
+++ b/style.css
@@ -102,6 +102,9 @@ nav { margin-left: auto; }
 .btn:hover { filter: brightness(1.05); }
 .btn:focus-visible { outline: 2px solid var(--ring); outline-offset: 2px; }
 
+/* Mini game */
+.game-controls { display: flex; flex-wrap: wrap; gap: .5rem; margin-top: .5rem; }
+
 /* Footer */
 .site-footer { padding: 1rem 0; border-top: 1px solid rgba(0,0,0,.06); margin-top: 2rem; }
 .footer-inner { display: flex; align-items: center; justify-content: space-between; gap: .75rem; }


### PR DESCRIPTION
## Summary
- add navigation link and section for a number guessing mini game
- style game controls and layout
- implement game logic with guess and reset actions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc73a8f9ec83238f629dfd6c990597