### PR TITLE
Switch site to light theme only

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Minimalist, mobile‑first static site ready for GitHub Pages. No frameworks, no
 - Semantic HTML with proper landmarks and heading order
 - Mobile‑first layout, responsive typography (`clamp()`), CSS Grid/Flex
 - Accessible menu toggle with ARIA and keyboard support
-- Dark mode via `prefers-color-scheme`
+- Light theme only
 - Smooth scrolling that respects reduced motion
 - System font stack, no blocking web fonts
 - Relative asset paths to work under `/REPO/` and custom domains

--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
           </div>
           <div>
             <h2>Design</h2>
-            <p>Minimal layout with a single accent color and a crisp system font stack. Dark mode included via prefers‑color‑scheme.</p>
+            <p>Minimal layout with a single accent color and a crisp system font stack. Light theme only.</p>
           </div>
         </div>
       </section>

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
   Minimal reset and variables
   - System fonts
-  - Light/dark themes
+  - Light theme
   - Mobile-first, responsive container
 */
 
@@ -26,20 +26,8 @@ input, button, textarea, select { font: inherit; }
   --shadow: 0 1px 2px rgba(0,0,0,.06), 0 1px 3px rgba(0,0,0,.1);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg: #0b0e12;
-    --fg: #e5e7eb;
-    --muted: #a1a1aa;
-    --accent: #f472b6;
-    --accent-contrast: #0b0e12;
-    --surface: #12161c;
-    --ring: #f9a8d4;
-  }
-}
-
 /* Base */
-html { color-scheme: light dark; }
+html { color-scheme: light; }
 body {
   background: var(--bg);
   color: var(--fg);


### PR DESCRIPTION
## Summary
- remove prefers-color-scheme dark styles
- adjust design copy to note light theme
- update README features

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8cf3fc1483238d217d7da4ab11bc