### PR TITLE
style: simplify theme

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -2,13 +2,13 @@
   --bg: #ffffff;
   --fg: #111111;
   --muted: #555555;
-  --accent: #2563eb;
-  --card: #f5f5f5;
+  --accent: #111111;
+  --card: var(--bg);
   --border: #e5e7eb;
-  --radius: 0.5rem;
-  --shadow: 0 1px 2px rgba(0,0,0,0.1);
+  --radius: 0;
+  --shadow: none;
   --space: 1rem;
-  --maxw: 1120px;
+  --maxw: 720px;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -16,8 +16,8 @@
     --bg: #111111;
     --fg: #f5f5f5;
     --muted: #9ca3af;
-    --accent: #93c5fd;
-    --card: #1f2937;
+    --accent: #f5f5f5;
+    --card: var(--bg);
     --border: #374151;
   }
 }
@@ -40,6 +40,7 @@ header {
 
 .nav {
   display: flex;
+  justify-content: center;
   gap: var(--space);
   list-style: none;
   padding: var(--space);
@@ -71,8 +72,6 @@ section {
   background: var(--card);
   border: 1px solid var(--border);
   padding: var(--space);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
 }
 
 .chips {
@@ -83,14 +82,13 @@ section {
 }
 .chip {
   padding: 0.25rem 0.5rem;
-  border-radius: var(--radius);
-  background: var(--card);
   border: 1px solid var(--border);
+  background: transparent;
   cursor: pointer;
 }
 .chip.active {
   background: var(--accent);
-  color: #fff;
+  color: var(--bg);
 }
 
 footer {
@@ -112,18 +110,21 @@ footer {
 .skip:focus {
   left: 0;
   background: var(--accent);
-  color: #fff;
+  color: var(--bg);
   padding: 0.5rem;
 }
 
 .btn {
   padding: 0.5rem 1rem;
-  background: var(--accent);
-  color: #fff;
-  border: none;
-  border-radius: var(--radius);
+  background: transparent;
+  color: var(--fg);
+  border: 1px solid var(--fg);
   text-decoration: none;
   display: inline-block;
+}
+.btn:hover {
+  background: var(--fg);
+  color: var(--bg);
 }
 
 .print-area {


### PR DESCRIPTION
## Summary
- refine CSS variables for a minimalist palette and layout
- remove rounded corners and shadows for cards, chips, and buttons
- outline-style buttons and centered navigation for a clean look

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc91d020908323a905b84937a893e8