### PR TITLE
Refine portfolio layout and accessibility

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -19,7 +19,7 @@ h1 { font-size:clamp(28px,3vw,40px); }
 h2 { font-size:clamp(18px,2vw,24px); color:var(--muted); }
 
 a { color:var(--accent); }
-a:focus, button:focus, summary:focus { outline:2px solid var(--accent); outline-offset:2px; }
+a:focus, button:focus { outline:2px solid var(--accent); outline-offset:2px; }
 
 header {
   position:sticky; top:0; background:var(--bg);
@@ -29,10 +29,12 @@ header {
 .nav a { text-decoration:none; color:inherit; padding:4px 8px; }
 .nav a.active { border-bottom:2px solid var(--accent); }
 
-section { padding:64px 16px; max-width:var(--maxw); margin:0 auto; }
+section { padding:64px 16px; max-width:var(--maxw); margin:0 auto; scroll-margin-top:80px; }
 
-.chips { display:flex; flex-wrap:wrap; gap:8px; margin:20px 0; color:var(--muted); }
-.chip { border:1px solid var(--border); padding:4px 8px; border-radius:var(--radius); }
+.noscript-msg{background:var(--accent);color:var(--bg);text-align:center;padding:8px;}
+
+.chips { display:flex; flex-wrap:wrap; gap:8px; margin:20px 0; }
+.chip { border:1px solid var(--border); padding:4px 8px; border-radius:var(--radius); color:var(--muted); text-transform:lowercase; }
 
 .btn { display:inline-block; padding:8px 16px; border:1px solid var(--accent); color:var(--accent); text-decoration:none; border-radius:var(--radius); }
 .btn:hover { background:var(--accent); color:var(--bg); }
@@ -41,11 +43,12 @@ section { padding:64px 16px; max-width:var(--maxw); margin:0 auto; }
 .card { border:1px solid var(--border); border-radius:var(--radius); padding:16px; transition:transform .1s; background:var(--bg); }
 .card:hover { transform:translateY(-1px); }
 
+.toggle{background:none;border:none;color:var(--accent);cursor:pointer;padding:0;margin-top:8px;}
+
+.impact{padding-left:20px;margin-top:8px;}
+
 .skills { display:grid; gap:20px; }
 .skills .card ul { padding-left:20px; }
-
-summary { cursor:pointer; list-style:none; }
-details > summary::-webkit-details-marker { display:none; }
 
 footer { text-align:center; padding:20px; border-top:1px solid var(--border); }
 

--- a/css/no-js.css
+++ b/css/no-js.css
@@ -1,1 +1,2 @@
 body {font-family: ui-sans-serif, -apple-system, "Segoe UI", Roboto, Inter, Arial, sans-serif; margin:1rem;}
+.toggle{display:none;}

--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
 </head>
 <body>
   <a class="skip" href="#home">Skip to content</a>
+  <noscript><p class="noscript-msg">JavaScript is disabled; interactive enhancements are unavailable.</p></noscript>
   <header id="top">
     <nav>
       <ul class="nav">
@@ -61,55 +62,46 @@
       <h1>Kevin Varghese</h1>
       <h2>Business / Data / Systems Analyst — Toronto</h2>
       <p>I turn messy processes into measurable outcomes.</p>
-      <div class="chips">
-        <span class="chip">ECBA-certified</span>
-        <span class="chip">Agile SDLC &amp; UAT</span>
-        <span class="chip">SQL/Python/Tableau</span>
-      </div>
       <p class="cta">
         <a class="btn" href="#projects">View Projects</a>
         <a class="btn" href="assets/kevin-varghese-resume.pdf">Download Resume</a>
       </p>
-      <noscript>JavaScript is disabled; interactive enhancements are unavailable.</noscript>
     </section>
 
     <section id="projects">
       <h2>Projects</h2>
       <div class="cards">
-        <details class="card">
-          <summary>
-            <h3>A/B Testing — Onboarding <small>2024</small></h3>
-            <p>Stat-rigorous test improved first-week engagement.</p>
-            <div class="chips"><span class="chip">Analytics</span><span class="chip">Experiment</span><span class="chip">Dashboard</span></div>
-          </summary>
-          <ul>
-            <li>~5% lift (p &lt; 0.001)</li>
-            <li>Dashboard readouts</li>
-            <li>Rollout playbook</li>
+        <div class="card">
+          <h3>A/B Testing — Onboarding <small>2024</small></h3>
+          <p>Stat-rigorous test improved first-week engagement.</p>
+          <div class="chips"><span class="chip">analytics</span><span class="chip">experiment</span><span class="chip">dashboard</span></div>
+          <button class="toggle" aria-expanded="true">Details</button>
+          <ul class="impact">
+            <li>~5% lift (p&lt;0.001)</li>
+            <li>dashboards</li>
+            <li>rollout playbook</li>
           </ul>
-        </details>
-        <details class="card">
-          <summary>
-            <h3>Churn Prediction (SaaS) <small>2024</small></h3>
-            <p>Logistic model to target retention outreach.</p>
-            <div class="chips"><span class="chip">ML</span><span class="chip">EDA</span><span class="chip">Logistic Regression</span></div>
-          </summary>
-          <ul>
+        </div>
+        <div class="card">
+          <h3>Churn Prediction (SaaS) <small>2024</small></h3>
+          <p>Logistic model prioritised outreach.</p>
+          <div class="chips"><span class="chip">ml</span><span class="chip">eda</span><span class="chip">logistic-regression</span></div>
+          <button class="toggle" aria-expanded="true">Details</button>
+          <ul class="impact">
             <li>ROC-AUC ~0.76</li>
-            <li>Driver insights</li>
+            <li>driver insights</li>
           </ul>
-        </details>
-        <details class="card">
-          <summary>
-            <h3>Claims System Redesign <small>2024</small></h3>
-            <p>As-Is/To-Be, validations, and portal prototype.</p>
-            <div class="chips"><span class="chip">Systems Analysis</span><span class="chip">UX</span><span class="chip">Process Mapping</span></div>
-          </summary>
-          <ul>
-            <li>Cycle-time target 30–40%↓</li>
-            <li>Error reduction goals</li>
+        </div>
+        <div class="card">
+          <h3>Claims System Redesign <small>2024</small></h3>
+          <p>As-Is/To-Be, validations, portal prototype.</p>
+          <div class="chips"><span class="chip">systems analysis</span><span class="chip">ux</span><span class="chip">process mapping</span></div>
+          <button class="toggle" aria-expanded="true">Details</button>
+          <ul class="impact">
+            <li>cycle-time target 30–40%↓</li>
+            <li>error-reduction goals</li>
           </ul>
-        </details>
+        </div>
       </div>
     </section>
 
@@ -170,7 +162,7 @@
 
     <section id="contact">
       <h2>Contact</h2>
-      <p><a class="btn" href="mailto:kevin@example.com?subject=Hello%20Kevin&amp;body=Hi%20Kevin,">Email</a> <a class="btn" href="https://www.linkedin.com/in/...">LinkedIn</a></p>
+      <p><a href="mailto:kevin@example.com">kevin@example.com</a> <a class="btn" href="https://www.linkedin.com/in/...">LinkedIn</a></p>
     </section>
   </main>
 

--- a/js/main.js
+++ b/js/main.js
@@ -2,6 +2,7 @@
   document.addEventListener('DOMContentLoaded', () => {
     setupScroll();
     setupObserver();
+    setupAccordion();
   });
 
   function setupScroll(){
@@ -29,6 +30,19 @@
       });
     }, {rootMargin:'-50% 0px -50% 0px'});
     sections.forEach(s=>obs.observe(s));
+  }
+
+  function setupAccordion(){
+    document.querySelectorAll('.card .toggle').forEach(btn=>{
+      const panel = btn.nextElementSibling;
+      btn.setAttribute('aria-expanded','false');
+      panel.hidden = true;
+      btn.addEventListener('click', ()=>{
+        const expanded = btn.getAttribute('aria-expanded') === 'true';
+        btn.setAttribute('aria-expanded', String(!expanded));
+        panel.hidden = expanded;
+      });
+    });
   }
 })();
 

--- a/resume.html
+++ b/resume.html
@@ -4,23 +4,56 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Kevin Varghese — Resume</title>
+  <meta name="description" content="Resume of Kevin Varghese, Business/Data/Systems Analyst in Toronto, Canada." />
   <link rel="stylesheet" href="./css/main.css" />
-  <style>section{max-width:700px;margin:40px auto;}@media print{section{margin:0;}}</style>
+  <style>
+    main{max-width:700px;margin:40px auto;padding:0 16px;}
+    @media print{main{margin:0;} .no-print{display:none;}}
+  </style>
 </head>
 <body>
-  <section>
+  <main>
     <h1>Kevin Varghese</h1>
     <p>Business / Data / Systems Analyst — Toronto</p>
-    <h2>Experience</h2>
-    <ul>
-      <li><strong>Business Analyst</strong> — Example Corp (2023–2024)</li>
-      <li><strong>Data Analyst</strong> — Another Co (2022–2023)</li>
-    </ul>
-    <h2>Education</h2>
-    <ul>
-      <li>Bachelor of Science, University of Somewhere (2022)</li>
-    </ul>
-  </section>
+
+    <section>
+      <h2>Summary</h2>
+      <p>Analyst turning messy processes into measurable outcomes.</p>
+    </section>
+
+    <section>
+      <h2>Experience</h2>
+      <ul>
+        <li><strong>Business Analyst</strong> — Example Corp (2023–2024)</li>
+        <li><strong>Data Analyst</strong> — Another Co (2022–2023)</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Projects</h2>
+      <ul>
+        <li>A/B Testing — Onboarding (2024)</li>
+        <li>Churn Prediction (SaaS) (2024)</li>
+        <li>Claims System Redesign (2024)</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Skills</h2>
+      <ul>
+        <li>Requirements, BPMN, user stories</li>
+        <li>SQL, Python, Tableau</li>
+        <li>Agile, change management</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Education</h2>
+      <ul>
+        <li>Bachelor of Science, University of Somewhere (2022)</li>
+      </ul>
+    </section>
+  </main>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- Move JavaScript-disabled notice into `<noscript>` and trim hero to essential copy with two CTAs
- Rework project cards into accessible accordions and add scroll-margin offsets for sticky header
- Add structured HTML resume page with print styles and expose plain mailto contact

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9cf002c0832397483a05f8c1c81c