### PR TITLE
feat: add lifecycle rail for skills

### DIFF
--- a/assets/content.json
+++ b/assets/content.json
@@ -57,6 +57,55 @@
     "tools": ["JIRA","Confluence","Figma","Lucidchart","Visio","GitHub"],
     "methods": ["Agile/Scrum","KPI Design","Data Quality","Root-Cause Analysis"]
   },
+  "lifecycle": {
+    "steps": [
+      {
+        "id": "discover",
+        "title": "Discover",
+        "summary": "Understand the problem, users, and constraints.",
+        "skills": ["stakeholder interviews", "requirements elicitation", "data profiling", "KPI framing"],
+        "kpis": ["clear problem statement", "stakeholder alignment"],
+        "artifact": {"label": "discovery brief", "href": "/assets/docs/discovery-brief.pdf"},
+        "project_ref": "claims-redesign"
+      },
+      {
+        "id": "define",
+        "title": "Define",
+        "summary": "Specify what to build and how to measure success.",
+        "skills": ["BRD & user stories", "acceptance criteria", "process mapping (BPMN)"],
+        "kpis": ["zero-ambiguity handoffs", "traceability in change log"],
+        "artifact": {"label": "BRD sample", "href": "/assets/docs/brd-sample.pdf"},
+        "project_ref": "claims-redesign"
+      },
+      {
+        "id": "build",
+        "title": "Build",
+        "summary": "Prototype, model, and instrument for insight.",
+        "skills": ["SQL & pandas", "dashboarding (Tableau)", "rapid prototyping"],
+        "kpis": ["insight-to-action pipeline", "exec-ready visuals"],
+        "artifact": {"label": "dashboard snapshot", "href": "/assets/docs/dashboard.pdf"},
+        "project_ref": "telco-churn"
+      },
+      {
+        "id": "validate",
+        "title": "Validate",
+        "summary": "De-risk with tests and experiments.",
+        "skills": ["UAT & defect triage", "test cases", "A/B testing (power, t-tests)"],
+        "kpis": ["+5% engagement (p<0.001)", "12 defects blocked pre–go-live"],
+        "artifact": {"label": "A/B readout", "href": "/assets/docs/ab-readout.pdf"},
+        "project_ref": "fintech-ab-test"
+      },
+      {
+        "id": "deliver",
+        "title": "Deliver",
+        "summary": "Roll out with clarity and measurable outcomes.",
+        "skills": ["exec readouts", "change logs", "rollout playbook"],
+        "kpis": ["cycle-time target 30–40%↓", "errors <1%"],
+        "artifact": {"label": "exec deck", "href": "/assets/docs/exec-deck.pdf"},
+        "project_ref": "claims-redesign"
+      }
+    ]
+  },
   "resume": {
     "pdf": "/assets/kevin-varghese-resume.pdf",
     "last_updated": "2025-09-01"

--- a/assets/docs/ab-readout.pdf
+++ b/assets/docs/ab-readout.pdf
@@ -1,0 +1,1 @@
+Placeholder ab-readout.pdf

--- a/assets/docs/brd-sample.pdf
+++ b/assets/docs/brd-sample.pdf
@@ -1,0 +1,1 @@
+Placeholder brd-sample.pdf

--- a/assets/docs/churn-summary.pdf
+++ b/assets/docs/churn-summary.pdf
@@ -1,0 +1,1 @@
+Placeholder churn-summary.pdf

--- a/assets/docs/claims-redesign.pdf
+++ b/assets/docs/claims-redesign.pdf
@@ -1,0 +1,1 @@
+Placeholder claims-redesign.pdf

--- a/assets/docs/dashboard.pdf
+++ b/assets/docs/dashboard.pdf
@@ -1,0 +1,1 @@
+Placeholder dashboard.pdf

--- a/assets/docs/discovery-brief.pdf
+++ b/assets/docs/discovery-brief.pdf
@@ -1,0 +1,1 @@
+Placeholder discovery-brief.pdf

--- a/assets/docs/exec-deck.pdf
+++ b/assets/docs/exec-deck.pdf
@@ -1,0 +1,1 @@
+Placeholder exec-deck.pdf

--- a/css/main.css
+++ b/css/main.css
@@ -87,6 +87,40 @@ section { padding:64px 16px; max-width:var(--maxw); margin:0 auto; scroll-margin
 .skills { display:grid; gap:20px; }
 .skills .card ul { padding-left:20px; }
 
+/* Lifecycle rail */
+#skills{
+  --bg:#fff;
+  --fg:#111;
+  --muted:#6b7280;
+  --accent:#1a73e8;
+  --border:#eaeaea;
+  --radius:12px;
+  background:var(--bg);
+  color:var(--fg);
+  font-family:system-ui,sans-serif;
+}
+#skills a{color:var(--accent);}
+#skills .rail{display:none;border-bottom:1px solid var(--border);margin-bottom:24px;}
+.js #skills .rail{display:flex;justify-content:space-between;}
+#skills .rail button{flex:1;background:none;border:none;padding:8px 0;font-size:clamp(14px,1.6vw,16px);cursor:pointer;color:inherit;}
+#skills .rail button[aria-selected="true"]{border-bottom:2px solid var(--accent);color:var(--accent);}
+#skills .rail button:focus{outline:2px solid var(--accent);outline-offset:2px;}
+#skills .rail-panels>section{margin-top:24px;}
+.js #skills .rail-panels>section{display:none;}
+.js #skills .rail-panels>section.is-active{display:block;}
+#skills .chips{display:flex;flex-wrap:wrap;gap:8px;padding:0;margin:16px 0;}
+#skills .chips li{list-style:none;border:1px solid var(--border);border-radius:9999px;padding:4px 10px;font-size:14px;}
+#skills .chips.skills li{color:var(--muted);}
+#skills .chips.kpis li{color:var(--accent);}
+#skills .artifact{margin-top:16px;}
+#skills .artifact a+a{margin-left:8px;}
+#skills .chip-link{border:1px solid var(--accent);border-radius:9999px;padding:4px 10px;text-decoration:none;}
+#skills .chip-link:hover{background:var(--accent);color:var(--bg);}
+@media (prefers-reduced-motion: no-preference){
+  .js #skills .rail-panels>section.is-active{animation:fade .15s ease;}
+}
+@keyframes fade{from{opacity:0;transform:translateY(5px);}to{opacity:1;transform:translateY(0);}}
+
 footer { text-align:center; padding:20px; border-top:1px solid var(--border); }
 
 .skip { position:absolute; left:-9999px; }

--- a/index.html
+++ b/index.html
@@ -113,48 +113,109 @@
       </div>
     </section>
 
-    <section id="skills">
-      <h2>Skills</h2>
-      <div class="skills">
-        <div class="card">
-          <h3>Core</h3>
-          <ul>
-            <li>BRD/Requirements</li>
-            <li>BPMN Process Maps</li>
-            <li>User Stories &amp; AC</li>
-            <li>UAT &amp; Defect Triage</li>
-            <li>Change Management</li>
-          </ul>
+    <section id="skills" aria-labelledby="skills-h2">
+      <div class="container">
+        <h2 id="skills-h2">How I Work</h2>
+
+        <div class="rail" role="tablist" aria-label="Lifecycle steps">
+          <button role="tab" id="tab-discover" aria-controls="panel-discover" aria-selected="true">Discover</button>
+          <button role="tab" id="tab-define" aria-controls="panel-define" aria-selected="false">Define</button>
+          <button role="tab" id="tab-build" aria-controls="panel-build" aria-selected="false">Build</button>
+          <button role="tab" id="tab-validate" aria-controls="panel-validate" aria-selected="false">Validate</button>
+          <button role="tab" id="tab-deliver" aria-controls="panel-deliver" aria-selected="false">Deliver</button>
         </div>
-        <div class="card">
-          <h3>Data</h3>
-          <ul>
-            <li>SQL</li>
-            <li>Python (pandas)</li>
-            <li>Excel/Power Query</li>
-            <li>Tableau</li>
-            <li>Experimentation</li>
-          </ul>
-        </div>
-        <div class="card">
-          <h3>Tools</h3>
-          <ul>
-            <li>JIRA</li>
-            <li>Confluence</li>
-            <li>Figma</li>
-            <li>Lucidchart</li>
-            <li>Visio</li>
-            <li>GitHub</li>
-          </ul>
-        </div>
-        <div class="card">
-          <h3>Methods</h3>
-          <ul>
-            <li>Agile/Scrum</li>
-            <li>KPI Design</li>
-            <li>Data Quality</li>
-            <li>Root-Cause Analysis</li>
-          </ul>
+
+        <div class="rail-panels">
+          <section id="panel-discover" role="tabpanel" aria-labelledby="tab-discover">
+            <h3>Discover</h3>
+            <p class="summary">Understand the problem, users, and constraints.</p>
+            <ul class="chips skills">
+              <li>stakeholder interviews</li>
+              <li>requirements elicitation</li>
+              <li>data profiling</li>
+              <li>KPI framing</li>
+            </ul>
+            <ul class="chips kpis">
+              <li>clear problem statement</li>
+              <li>stakeholder alignment</li>
+            </ul>
+            <p class="artifact">
+              <a href="/assets/docs/discovery-brief.pdf">discovery brief (PDF)</a>
+              <a href="#projects" data-project="claims-redesign" class="chip-link">related project</a>
+            </p>
+          </section>
+
+          <section id="panel-define" role="tabpanel" aria-labelledby="tab-define">
+            <h3>Define</h3>
+            <p class="summary">Specify what to build and how to measure success.</p>
+            <ul class="chips skills">
+              <li>BRD &amp; user stories</li>
+              <li>acceptance criteria</li>
+              <li>process mapping (BPMN)</li>
+            </ul>
+            <ul class="chips kpis">
+              <li>zero-ambiguity handoffs</li>
+              <li>traceability in change log</li>
+            </ul>
+            <p class="artifact">
+              <a href="/assets/docs/brd-sample.pdf">BRD sample (PDF)</a>
+              <a href="#projects" data-project="claims-redesign" class="chip-link">related project</a>
+            </p>
+          </section>
+
+          <section id="panel-build" role="tabpanel" aria-labelledby="tab-build">
+            <h3>Build</h3>
+            <p class="summary">Prototype, model, and instrument for insight.</p>
+            <ul class="chips skills">
+              <li>SQL &amp; pandas</li>
+              <li>dashboarding (Tableau)</li>
+              <li>rapid prototyping</li>
+            </ul>
+            <ul class="chips kpis">
+              <li>insight-to-action pipeline</li>
+              <li>exec-ready visuals</li>
+            </ul>
+            <p class="artifact">
+              <a href="/assets/docs/dashboard.pdf">dashboard snapshot (PDF)</a>
+              <a href="#projects" data-project="telco-churn" class="chip-link">related project</a>
+            </p>
+          </section>
+
+          <section id="panel-validate" role="tabpanel" aria-labelledby="tab-validate">
+            <h3>Validate</h3>
+            <p class="summary">De-risk with tests and experiments.</p>
+            <ul class="chips skills">
+              <li>UAT &amp; defect triage</li>
+              <li>test cases</li>
+              <li>A/B testing (power, t-tests)</li>
+            </ul>
+            <ul class="chips kpis">
+              <li>+5% engagement (p&lt;0.001)</li>
+              <li>12 defects blocked pre–go-live</li>
+            </ul>
+            <p class="artifact">
+              <a href="/assets/docs/ab-readout.pdf">A/B readout (PDF)</a>
+              <a href="#projects" data-project="fintech-ab-test" class="chip-link">related project</a>
+            </p>
+          </section>
+
+          <section id="panel-deliver" role="tabpanel" aria-labelledby="tab-deliver">
+            <h3>Deliver</h3>
+            <p class="summary">Roll out with clarity and measurable outcomes.</p>
+            <ul class="chips skills">
+              <li>exec readouts</li>
+              <li>change logs</li>
+              <li>rollout playbook</li>
+            </ul>
+            <ul class="chips kpis">
+              <li>cycle-time target 30–40%↓</li>
+              <li>errors &lt;1%</li>
+            </ul>
+            <p class="artifact">
+              <a href="/assets/docs/exec-deck.pdf">exec deck (PDF)</a>
+              <a href="#projects" data-project="claims-redesign" class="chip-link">related project</a>
+            </p>
+          </section>
         </div>
       </div>
     </section>

--- a/js/main.js
+++ b/js/main.js
@@ -1,8 +1,10 @@
 (function(){
+  document.documentElement.classList.add('js');
   document.addEventListener('DOMContentLoaded', () => {
     setupScroll();
     setupObserver();
     setupAccordion();
+    setupLifecycle();
   });
 
   function setupScroll(){
@@ -43,6 +45,43 @@
         panel.hidden = expanded;
       });
     });
+  }
+
+  function setupLifecycle(){
+    const rail = document.querySelector('#skills .rail');
+    if(!rail) return;
+    const tabs = Array.from(rail.querySelectorAll('[role="tab"]'));
+    const panels = Array.from(document.querySelectorAll('#skills [role="tabpanel"]'));
+
+    const ids = tabs.map(t=>t.id.replace('tab-',''));
+    function activate(id){
+      tabs.forEach(t=>{
+        const sel = t.id === `tab-${id}`;
+        t.setAttribute('aria-selected', sel);
+      });
+      panels.forEach(p=>{
+        const active = p.id === `panel-${id}`;
+        p.classList.toggle('is-active', active);
+        p.hidden = !active;
+      });
+      history.replaceState(null, '', `#phase=${id}`);
+    }
+
+    tabs.forEach((tab,idx)=>{
+      tab.addEventListener('click', ()=>activate(ids[idx]));
+      tab.addEventListener('keydown', e=>{
+        let i = idx;
+        if(e.key === 'ArrowRight'){ e.preventDefault(); tabs[(i+1)%tabs.length].focus(); }
+        else if(e.key === 'ArrowLeft'){ e.preventDefault(); tabs[(i-1+tabs.length)%tabs.length].focus(); }
+        else if(e.key === 'Home'){ e.preventDefault(); tabs[0].focus(); }
+        else if(e.key === 'End'){ e.preventDefault(); tabs[tabs.length-1].focus(); }
+        else if(e.key === 'Enter' || e.key === ' '){ e.preventDefault(); activate(ids[i]); }
+      });
+    });
+
+    const param = new URLSearchParams(location.hash.replace('#','')).get('phase');
+    const start = ids.includes(param) ? param : ids[0];
+    activate(start);
   }
 })();
 


### PR DESCRIPTION
## Summary
- add lifecycle steps and artifacts to content.json
- replace skills list with tabbed lifecycle rail
- implement lightweight styles and script for accessible tab behavior

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bca88c3ac08323b132069ae9b56320