### PR TITLE
style: inherit font for lifecycle rail buttons

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -94,7 +94,7 @@ section { padding:64px 16px; max-width:var(--maxw); margin:0 auto; scroll-margin
 }
 #skills .rail{display:none;border-bottom:1px solid var(--border);margin-bottom:24px;}
 .js #skills .rail{display:flex;justify-content:space-between;}
-#skills .rail button{flex:1;background:none;border:none;padding:8px 0;font-size:clamp(14px,1.6vw,16px);cursor:pointer;color:inherit;}
+#skills .rail button{flex:1;background:none;border:none;padding:8px 0;font-size:clamp(14px,1.6vw,16px);cursor:pointer;color:inherit;font-family:inherit;}
 #skills .rail button[aria-selected="true"]{border-bottom:2px solid var(--accent);color:var(--accent);}
 #skills .rail button:focus{outline:2px solid var(--accent);outline-offset:2px;}
 #skills .rail-panels>section{margin-top:24px;}


### PR DESCRIPTION
## Summary
- ensure "How I Work" rail buttons use site's primary font by inheriting font family

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcac4d20d08323ab4bcd14df33aa21