### PR TITLE
Improve accordion accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Minimalist, mobile‑first static site ready for GitHub Pages. No frameworks, no
 ## Features
 - Semantic HTML with proper landmarks and heading order
 - Mobile‑first layout, responsive typography (`clamp()`), CSS Grid/Flex
-- Accessible menu toggle with ARIA and keyboard support
+- Accessible project accordion with ARIA and keyboard support
 - Sci-fi dark theme with neon accents
 - Smooth scrolling that respects reduced motion
 - Orbitron web font for futuristic feel
@@ -18,18 +18,20 @@ Minimalist, mobile‑first static site ready for GitHub Pages. No frameworks, no
 .
 ├── 404.html
 ├── README.md
+├── assets/
+│   ├── content.json
+│   ├── docs/
+│   └── …
+├── css/
+│   ├── main.css
+│   └── no-js.css
 ├── index.html
+├── js/
+│   └── main.js
+├── resume.html
 ├── robots.txt
-├── script.js
 ├── sitemap.xml
-├── site.webmanifest
-├── style.css
-└── assets/
-    ├── favicon.png
-    ├── favicon.svg
-    ├── icon-192.png
-    ├── icon-512.png
-    └── logo.svg
+└── site.webmanifest
 ```
 
 ## Local Preview

--- a/css/no-js.css
+++ b/css/no-js.css
@@ -1,2 +1,3 @@
 body {font-family: ui-sans-serif, -apple-system, "Segoe UI", Roboto, Inter, Arial, sans-serif; margin:1rem;}
 .toggle{display:none;}
+.impact{display:block !important;}

--- a/index.html
+++ b/index.html
@@ -78,39 +78,39 @@
 
     <section id="projects">
       <h2>Projects</h2>
-      <div class="cards">
-        <div class="card">
-          <h3>A/B Testing — Onboarding <small>2024</small></h3>
-          <p>Stat-rigorous test improved first-week engagement.</p>
-          <div class="chips"><span class="chip">analytics</span><span class="chip">experiment</span><span class="chip">dashboard</span></div>
-          <button class="toggle" aria-expanded="true">Details</button>
-          <ul class="impact">
-            <li>~5% lift (p&lt;0.001)</li>
-            <li>dashboards</li>
-            <li>rollout playbook</li>
-          </ul>
+        <div class="cards">
+          <div class="card">
+            <h3>A/B Testing — Onboarding <small>2024</small></h3>
+            <p>Stat-rigorous test improved first-week engagement.</p>
+            <div class="chips"><span class="chip">analytics</span><span class="chip">experiment</span><span class="chip">dashboard</span></div>
+            <button class="toggle" aria-expanded="false" aria-controls="impact-onboarding">Details</button>
+            <ul id="impact-onboarding" class="impact" hidden>
+              <li>~5% lift (p&lt;0.001)</li>
+              <li>dashboards</li>
+              <li>rollout playbook</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>Churn Prediction (SaaS) <small>2024</small></h3>
+            <p>Logistic model prioritised outreach.</p>
+            <div class="chips"><span class="chip">ml</span><span class="chip">eda</span><span class="chip">logistic-regression</span></div>
+            <button class="toggle" aria-expanded="false" aria-controls="impact-churn">Details</button>
+            <ul id="impact-churn" class="impact" hidden>
+              <li>ROC-AUC ~0.76</li>
+              <li>driver insights</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>Claims System Redesign <small>2024</small></h3>
+            <p>As-Is/To-Be, validations, portal prototype.</p>
+            <div class="chips"><span class="chip">systems analysis</span><span class="chip">ux</span><span class="chip">process mapping</span></div>
+            <button class="toggle" aria-expanded="false" aria-controls="impact-claims">Details</button>
+            <ul id="impact-claims" class="impact" hidden>
+              <li>cycle-time target 30–40%↓</li>
+              <li>error-reduction goals</li>
+            </ul>
+          </div>
         </div>
-        <div class="card">
-          <h3>Churn Prediction (SaaS) <small>2024</small></h3>
-          <p>Logistic model prioritised outreach.</p>
-          <div class="chips"><span class="chip">ml</span><span class="chip">eda</span><span class="chip">logistic-regression</span></div>
-          <button class="toggle" aria-expanded="true">Details</button>
-          <ul class="impact">
-            <li>ROC-AUC ~0.76</li>
-            <li>driver insights</li>
-          </ul>
-        </div>
-        <div class="card">
-          <h3>Claims System Redesign <small>2024</small></h3>
-          <p>As-Is/To-Be, validations, portal prototype.</p>
-          <div class="chips"><span class="chip">systems analysis</span><span class="chip">ux</span><span class="chip">process mapping</span></div>
-          <button class="toggle" aria-expanded="true">Details</button>
-          <ul class="impact">
-            <li>cycle-time target 30–40%↓</li>
-            <li>error-reduction goals</li>
-          </ul>
-        </div>
-      </div>
     </section>
 
     <section id="skills" aria-labelledby="skills-h2">

--- a/js/main.js
+++ b/js/main.js
@@ -36,9 +36,7 @@
 
   function setupAccordion(){
     document.querySelectorAll('.card .toggle').forEach(btn=>{
-      const panel = btn.nextElementSibling;
-      btn.setAttribute('aria-expanded','false');
-      panel.hidden = true;
+      const panel = document.getElementById(btn.getAttribute('aria-controls'));
       btn.addEventListener('click', ()=>{
         const expanded = btn.getAttribute('aria-expanded') === 'true';
         btn.setAttribute('aria-expanded', String(!expanded));


### PR DESCRIPTION
## Summary
- hide project impact lists by default and expose via accessible accordion
- provide no-JS fallback for project details
- document updated structure and features

## Testing
- `npx htmlhint index.html resume.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb3cbb7388323b1a399b782e05116