### PR TITLE
chore: improve metadata and theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,14 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta
+      name="description"
+      content="TBR builds meaningful software with clarity, usefulness, and care."
+    />
     <title>TBR — Meaningful Software</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
     <style>
       :root {
         --accent: #0055ff;
@@ -159,7 +164,14 @@
   </head>
   <body>
     <header>
-      <button id="theme-toggle" class="theme-toggle">Theme</button>
+      <button
+        id="theme-toggle"
+        class="theme-toggle"
+        type="button"
+        aria-label="Toggle dark mode"
+      >
+        Toggle theme
+      </button>
       <nav>
         <a href="#home">Home</a>
         <a href="#projects">Projects</a>
@@ -310,11 +322,23 @@
     <footer>
       <small>The site is a living shelf of work in progress.</small>
     </footer>
-    <script>
-      const toggle = document.getElementById("theme-toggle");
-      toggle.addEventListener("click", () => {
-        document.documentElement.classList.toggle("dark");
-      });
-    </script>
+      <script>
+        const toggle = document.getElementById("theme-toggle");
+        const root = document.documentElement;
+        const stored = localStorage.getItem("theme");
+        if (
+          stored === "dark" ||
+          (!stored && window.matchMedia("(prefers-color-scheme: dark)").matches)
+        ) {
+          root.classList.add("dark");
+        }
+        if (toggle) {
+          toggle.addEventListener("click", () => {
+            root.classList.toggle("dark");
+            const theme = root.classList.contains("dark") ? "dark" : "light";
+            localStorage.setItem("theme", theme);
+          });
+        }
+      </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add description and color-scheme metadata
- make theme toggle accessible and remember user preference

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf3b997f083239e1e5dd108686aaa